### PR TITLE
Fixes some warnings that are treated as errors due to -Werror

### DIFF
--- a/bindings.cc
+++ b/bindings.cc
@@ -23,7 +23,7 @@
 #include <iostream>
 #include <fstream>
 #include <string.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <ncurses.h>
 
 #include "maildir.h"

--- a/global.cc
+++ b/global.cc
@@ -23,7 +23,7 @@
 #include <cstdlib>
 #include <fstream>
 #include <string.h>
-#include <malloc.h>
+#include <stdlib.h>
 
 #include "global.h"
 

--- a/lua.cc
+++ b/lua.cc
@@ -22,7 +22,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <string.h>
-#include <malloc.h>
+#include <stdlib.h>
 
 #include "lua.h"
 #include "bindings.h"

--- a/message.cc
+++ b/message.cc
@@ -71,7 +71,7 @@ std::string CMessage::flags()
     if (m_path.empty())
 	return (flags);
 
-    unsigned offset = m_path.find(":2,");
+    size_t offset = m_path.find(":2,");
     if (offset != std::string::npos)
       flags = m_path.substr(offset + 3);
 
@@ -227,7 +227,7 @@ std::string CMessage::format( std::string fmt )
    */
   for( int i = 0 ; std_name[i] ; ++i) {
 
-    unsigned int offset = result.find( std_name[i], 0 );
+    size_t offset = result.find( std_name[i], 0 );
 
     if ( ( offset != std::string::npos ) && ( offset < result.size() ) ) {
 


### PR DESCRIPTION
Errors discovered while testing on OpenBSD.
- malloc.h is obsolete.
- std::string::npos is a size_t so make sure it's comparison is too
  (warning: comparison is always true due to limited range of data type)
