### PR TITLE
Include missing header unistd.h

### DIFF
--- a/bindings.cc
+++ b/bindings.cc
@@ -25,6 +25,7 @@
 #include <string.h>
 #include <malloc.h>
 #include <ncurses.h>
+#include <unistd.h>
 
 #include "maildir.h"
 #include "lua.h"


### PR DESCRIPTION
I had to make this change to build on Debian sid as of 2013-05-10.
