### PR TITLE
Added unistd.h to message.cc because of unlink error

### DIFF
--- a/message.cc
+++ b/message.cc
@@ -23,6 +23,7 @@
 #include <fstream>
 #include <sstream>
 #include <string>
+#include <unistd.h>
 
 #include <mimetic/mimetic.h>
 


### PR DESCRIPTION
I was having problem building lumail on Ubuntu 13.04 so I had to add this header to message.cc to make it work.
