### PR TITLE
update maildirs after creating a new one

### DIFF
--- a/src/bindings.cc
+++ b/src/bindings.cc
@@ -2778,6 +2778,9 @@ int create_maildir(lua_State *L)
     else
         lua_pushboolean(L,0);
 
+    CGlobal *global = CGlobal::Instance();
+    global->update_maildirs();
+
     return 1;
 }
 


### PR DESCRIPTION
So that we see the new maildir without having to restart lumail
