### PR TITLE
make column highlight lua variable

### DIFF
--- a/lumail.lua
+++ b/lumail.lua
@@ -190,6 +190,16 @@ index_format( "[$FLAGS] $DAY/$MONTH/$YEAR $FROM - $SUBJECT" )
 --
 headers = { "$TO", "$FROM", "$DATE", "$SUBJECT" }
 
+--
+-- chose the highlight mode for the selected column in maildir and index mode.
+-- supported are underline,standout,reverse,blink,dim,bold. Default
+-- for maildir/index is standout
+--
+-- This might be useful if you use lumail inside a terminal multiplexer
+-- like tmux.
+--
+maildir_highlight_mode('standout')
+index_highlight_mode('standout')
 
 --
 -- When viewing the contents of a message it is possible to pipe

--- a/src/lua.cc
+++ b/src/lua.cc
@@ -112,13 +112,15 @@ struct CLuaMapping primitive_list[] =
     {"get_variables", "Retrieve all known-variables and their values.", (lua_CFunction) get_variables },
 
 /**
- * Colour getters/setters.  Defined in src/variables.cc
+ * Colour & highlight getters/setters.  Defined in src/variables.cc
  */
     {"attachment_colour", "Get/Set the colour to use for drawing attachments.", (lua_CFunction) attachment_colour },
     {"body_colour", "Get/Set the colour to use for drawing message-bodies.", (lua_CFunction) body_colour },
     {"header_colour", "Get/Set the colour to use for drawing message-headers.", (lua_CFunction) header_colour },
     {"unread_maildir_colour", "Get/Set the colour to use for drawing Maildirs which contain unread messages.", (lua_CFunction) unread_maildir_colour },
     {"unread_message_colour", "Get/Set the colour to use for drawing unread messages.", (lua_CFunction) unread_message_colour },
+    {"maildir_highlight_mode", "Get/Set maildir highlight mode.", (lua_CFunction) maildir_highlight_mode },
+    {"index_highlight_mode", "Get/Set index highlight mode.", (lua_CFunction) index_highlight_mode },
 
 /**
  * Index functions: defined in src/bindings_index.cc

--- a/src/screen.cc
+++ b/src/screen.cc
@@ -111,6 +111,32 @@ void CScreen::drawMaildir()
         unread_colour = DEFAULT_UNREAD_COLOUR;
 
     /**
+     * get the higlighting mode for the current column
+     */
+    std::string *highlight = global->get_variable( "maildir_highlight_mode");
+    int highlight_mode = A_STANDOUT;
+    if ( highlight != NULL )
+    {
+        if (*highlight == "underline")
+            highlight_mode = A_UNDERLINE;
+
+        else if (*highlight == "standout")
+            highlight_mode = A_STANDOUT;
+
+        else if (*highlight == "reverse")
+            highlight_mode = A_REVERSE;
+
+        else if (*highlight == "blink")
+            highlight_mode = A_BLINK;
+
+        else if (*highlight == "dim")
+            highlight_mode = A_DIM;
+
+        else if (*highlight == "bold")
+            highlight_mode = A_BOLD;
+    }
+
+    /**
      * The number of items we've found, vs. the size of the screen.
      */
     int count = display.size();
@@ -227,7 +253,7 @@ void CScreen::drawMaildir()
         }
 
         if (row == rowToHighlight)
-            attron(A_STANDOUT);
+            attron(highlight_mode);
 
         /**
          * The item we'll draw for this row.
@@ -342,6 +368,32 @@ void CScreen::drawIndex()
         unread_colour = DEFAULT_UNREAD_COLOUR;
 
     /**
+     * get the higlighting mode for the current column
+     */
+    std::string *highlight = global->get_variable( "index_highlight_mode");
+    int highlight_mode = A_STANDOUT;
+    if ( highlight != NULL )
+    {
+        if (*highlight == "underline")
+            highlight_mode = A_UNDERLINE;
+
+        else if (*highlight == "standout")
+            highlight_mode = A_STANDOUT;
+
+        else if (*highlight == "reverse")
+            highlight_mode = A_REVERSE;
+
+        else if (*highlight == "blink")
+            highlight_mode = A_BLINK;
+
+        else if (*highlight == "dim")
+            highlight_mode = A_DIM;
+
+        else if (*highlight == "bold")
+            highlight_mode = A_BOLD;
+    }
+
+    /**
      * The number of items we've found, vs. the size of the screen.
      */
     int count = messages->size();
@@ -422,7 +474,7 @@ void CScreen::drawIndex()
             cur = messages->at(mailIndex);
 
         if (row == rowToHighlight)
-            attron(A_UNDERLINE | A_STANDOUT);
+            attron(highlight_mode);
 
         /**
          * Is this message new/unread?

--- a/src/variables.cc
+++ b/src/variables.cc
@@ -86,7 +86,7 @@ int get_set_string_variable( lua_State *L, const char * name )
 
 
 /**
- ** Colour getters/setters.
+ ** Colour & highlight getters/setters.
  **/
 
 
@@ -131,7 +131,15 @@ int unread_maildir_colour(lua_State *L)
     return( get_set_string_variable( L, "unread_maildir_colour" ) );
 }
 
+int maildir_highlight_mode(lua_State *L)
+{
+    return get_set_string_variable( L , "maildir_highlight_mode");
+}
 
+int index_highlight_mode(lua_State *L)
+{
+    return get_set_string_variable( L , "index_highlight_mode");
+}
 
 
 /**

--- a/src/variables.h
+++ b/src/variables.h
@@ -34,13 +34,15 @@ int get_set_string_variable( lua_State *L, const char * name );
 
 
 /**
- * Colour getters/setters.
+ * Colour & highlight getters/setters.
  */
 int attachment_colour(lua_State *L);
 int body_colour(lua_State *L);
 int header_colour(lua_State *L);
 int unread_maildir_colour(lua_State *L);
 int unread_message_colour(lua_State *L);
+int maildir_highlight_mode(lua_State *L);
+int index_highlight_mode(lua_State *L);
 
 /**
  * General getters/setters.


### PR DESCRIPTION
The highlight mode of the current column in maildir/index mode can be
set with maildir/index_highlight_mode(). Available options are
underline,standout,reverse,blink,dim,bold. They map to the corresponding
ncurses video attributes.

This change is useful for people using tmux, which is known for having
trouble with different highlighting modes in ncurses programs.
