### PR TITLE
Remove unused iterators and add an explicit cast to suppress compiler

### DIFF
--- a/src/message.cc
+++ b/src/message.cc
@@ -77,7 +77,6 @@ CMessage::~CMessage()
      */
     if ( m_attachments.size() > 0 )
     {
-        std::vector<CAttachment*>::iterator it;
         for (CAttachment *cur : m_attachments)
         {
             DEBUG_LOG( "Deleting attachment object: " + cur->name() );
@@ -1439,8 +1438,6 @@ std::vector<std::string> CMessage::attachments()
     if ( m_attachments.empty() )
         parse_attachments();
 
-
-    std::vector<CAttachment>::iterator it;
     for (CAttachment *cur : m_attachments)
     {
         paths.push_back( cur->name() );

--- a/util/attachments.c
+++ b/util/attachments.c
@@ -320,7 +320,6 @@ int main( int argc, char *argv[] )
         /**
          * Iterate over each detected attachment.
          */
-        std::vector<CAttachment>::iterator it;
         int c = 0;
         for (CAttachment *cur : result)
         {
@@ -332,7 +331,7 @@ int main( int argc, char *argv[] )
                       << std::endl;
 
 
-            fprintf(stderr, "PART %d: %s\n", c , cur->body() );
+            fprintf(stderr, "PART %d: %s\n", c , (char *)cur->body() );
             c += 1;
             delete(cur);
         }


### PR DESCRIPTION
warning.
