### PR TITLE
Fix bug #214:

### DIFF
--- a/src/bindings_maildir.cc
+++ b/src/bindings_maildir.cc
@@ -473,7 +473,7 @@ static void push_maildir_mt(lua_State *L)
     if (created)
     {
         /* A new table was created, set it up now. */
-        luaL_register(L, NULL, maildir_mt_fields);
+        CLua::reg_funcs(L, maildir_mt_fields);
     }
 }
 
@@ -538,7 +538,7 @@ bool push_maildir_list(lua_State *L,
 CMaildirList check_maildir_list(lua_State *L, int index)
 {
     CMaildirList result;
-    size_t size = lua_objlen(L, index);
+    size_t size = CLua::len(L, index);
     for (size_t i=1; i<=size; ++i)
     {
         std::shared_ptr<CMaildir> md;

--- a/src/lua.cc
+++ b/src/lua.cc
@@ -912,3 +912,25 @@ CMaildirList CLua::call_maildirs(const char *name,
     return check_maildir_list(m_lua, -1);
 }
 
+
+void CLua::reg_funcs(lua_State *L, const luaL_Reg *funcs)
+{
+#if LUA_VERSION_NUM == 501
+    luaL_register(L, NULL, funcs);
+#elif LUA_VERSION_NUM == 502
+    luaL_setfuncs(L, funcs, 0);
+#else
+#error unsupported Lua version
+#endif
+}
+
+size_t CLua::len(lua_State *L, int index)
+{
+#if LUA_VERSION_NUM == 501
+    return lua_objlen(L, index);
+#elif LUA_VERSION_NUM == 502
+    return lua_rawlen(L, index);
+#else
+#error unsupported Lua version
+#endif
+}

--- a/src/lua.h
+++ b/src/lua.h
@@ -206,6 +206,22 @@ public:
     std::vector<std::shared_ptr<CMaildir> > call_maildirs(const char *name,
                                                           const std::vector<std::shared_ptr<CMaildir> > &maildirs);
 
+/**
+ ** Static helper methods.
+ **/
+ 
+    /**
+     * Register all the functions in funcs (up to a NULL, NULL sentinel)
+     * into the table at the top of the Lua stack.
+     */
+    static void reg_funcs(lua_State *L, const luaL_Reg *funcs);
+    
+    /**
+     * Return the length of the Lua value at a given index on the Lua
+     * stack (not using any metamethods).
+     */
+    static size_t len(lua_State *L, int index);
+
 protected:
 
     /**


### PR DESCRIPTION
- Support both Lua 5.1 and 5.2 by adding wrappers around a couple of Lua
  API functions which have changed between the versions.
